### PR TITLE
root path fix

### DIFF
--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -100,8 +100,12 @@ function path()
     $requestUri = array_get($_SERVER, 'REQUEST_URI', '');
 
     $requestUri = str_replace('?'.$queryString, '', $requestUri);
-
-    return '/'.ltrim(str_replace(dirname($scriptName), '', $requestUri), '/');
+    $scriptPath = dirname($scriptName);
+    if(!strlen(str_replace('/','',$scriptPath)) ){
+        return '/'.ltrim($requestUri, '/');
+     } else {
+        return '/'.ltrim(str_replace($scriptPath, '', $requestUri), '/');
+    }
 }
 
 /**


### PR DESCRIPTION
If the $scriptPath is just a /, as can happen with a REQUEST_URL of just
'/index.php', then it will break the script path.  The dirname of
/index.php is just / so it will turn /foo/bar to /foobar.