### PR TITLE
Upgrade webonyx/graphql-php library

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3657,27 +3657,29 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v0.9.7",
+            "version": "v0.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "7ef9f9167296e8e25c53bc4cc9c2e33b735aaa63"
+                "reference": "b17b1c33366d07877feb4299f207a420fbfe53b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/7ef9f9167296e8e25c53bc4cc9c2e33b735aaa63",
-                "reference": "7ef9f9167296e8e25c53bc4cc9c2e33b735aaa63",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/b17b1c33366d07877feb4299f207a420fbfe53b5",
+                "reference": "b17b1c33366d07877feb4299f207a420fbfe53b5",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=5.4,<8.0-DEV"
+                "php": ">=5.5,<8.0-DEV"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8"
+                "phpunit/phpunit": "^4.8",
+                "psr/http-message": "^1.0"
             },
             "suggest": {
-                "react/promise": "To use ReactPHP promise adapter"
+                "psr/http-message": "To use standard GraphQL server",
+                "react/promise": "To leverage async resolving on React PHP platform"
             },
             "type": "library",
             "autoload": {
@@ -3698,7 +3700,7 @@
                 "api",
                 "graphql"
             ],
-            "time": "2017-03-16T16:51:38+00:00"
+            "time": "2017-10-13T17:45:55+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",

--- a/src/Graphql/Graphql.php
+++ b/src/Graphql/Graphql.php
@@ -7,7 +7,7 @@ namespace Siler\Graphql;
 
 use GraphQL\Executor\Executor;
 use GraphQL\GraphQL;
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\BooleanType;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FloatType;

--- a/src/Graphql/SubscriptionManager.php
+++ b/src/Graphql/SubscriptionManager.php
@@ -4,7 +4,7 @@ namespace Siler\Graphql;
 
 use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\Parser;
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use Ratchet\ConnectionInterface;
 use function Siler\array_get;
 

--- a/tests/Unit/Graphql/GraphqlTest.php
+++ b/tests/Unit/Graphql/GraphqlTest.php
@@ -2,7 +2,8 @@
 
 namespace Siler\Test\Unit;
 
-use GraphQL\Schema;
+use GraphQL\Error\Error;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\BooleanType;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FloatType;
@@ -146,7 +147,7 @@ class GraphqlTest extends \PHPUnit\Framework\TestCase
 
         $root = Graphql\type('Root')([
             Graphql\str('foo')(function ($root, $args) {
-                throw new \Exception('error_message');
+                throw new Error('error_message');
             }),
         ]);
 

--- a/tests/fixtures/graphql_error.json
+++ b/tests/fixtures/graphql_error.json
@@ -1,1 +1,1 @@
-{"data":{"foo":null},"errors":[{"message":"error_message","locations":[{"line":1,"column":3}],"path":["foo"]}]}
+{"errors":[{"message":"error_message","category":"graphql","locations":[{"line":1,"column":3}],"path":["foo"]}],"data":{"foo":null}}


### PR DESCRIPTION
Upgrades the GraphQL library to latest version `v0.11.2`

Changes:
Upstream `GraphQL\Schema` class has been marked as deprecated.
Throws a `ClientAware` Exception in test case so error_message bubbles up