### PR TITLE
Improve assertions in tests

### DIFF
--- a/tests/Integration/FizzbuzzTest.php
+++ b/tests/Integration/FizzbuzzTest.php
@@ -24,6 +24,6 @@ class FizzbuzzTest extends \PHPUnit\Framework\TestCase
 
         $actual = array_map($match, $input);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/Integration/JwtAuthTest.php
+++ b/tests/Integration/JwtAuthTest.php
@@ -27,8 +27,8 @@ class JwtAuthTest extends \PHPUnit\Framework\TestCase
 
         self::$cookies['jwt'] = (string) $token;
 
-        $this->assertEquals(env('JWT_ISS'), $token->getClaim('iss'));
-        $this->assertEquals(1, $token->getClaim('uid'));
+        $this->assertSame(env('JWT_ISS'), $token->getClaim('iss'));
+        $this->assertSame(1, $token->getClaim('uid'));
     }
 
     /**
@@ -43,6 +43,6 @@ class JwtAuthTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(Jwt\validator(Jwt\conf(env('JWT_ISS'), env('JWT_AUD')), time())($token));
         $this->assertTrue($token->verify(new Sha256(), env('APP_KEY')));
 
-        $this->assertEquals(1, $token->getClaim('uid'));
+        $this->assertSame(1, $token->getClaim('uid'));
     }
 }

--- a/tests/Unit/Container/ContainerTest.php
+++ b/tests/Unit/Container/ContainerTest.php
@@ -15,7 +15,7 @@ class ContainerTest extends TestCase
 
     public function testGet()
     {
-        $this->assertEquals('test', Container\get('test'));
+        $this->assertSame('test', Container\get('test'));
     }
 
     public function testHas()

--- a/tests/Unit/Dotenv/DotenvTest.php
+++ b/tests/Unit/Dotenv/DotenvTest.php
@@ -11,11 +11,11 @@ class DotenvTest extends TestCase
     {
         $lines = \Siler\Dotenv\init(__DIR__.'/../../fixtures');
 
-        $this->assertEquals(4, count($lines));
-        $this->assertEquals('FOO=bar', $lines[0]);
-        $this->assertEquals($_SERVER, env());
-        $this->assertEquals('bar', env('FOO'));
-        $this->assertEquals('baz', env('BAR', 'baz'));
+        $this->assertCount(4, $lines);
+        $this->assertSame('FOO=bar', $lines[0]);
+        $this->assertSame($_SERVER, env());
+        $this->assertSame('bar', env('FOO'));
+        $this->assertSame('baz', env('BAR', 'baz'));
         $this->assertNull(env('BAR'));
     }
 }

--- a/tests/Unit/Functional/FunctionalTest.php
+++ b/tests/Unit/Functional/FunctionalTest.php
@@ -143,7 +143,7 @@ class FunctionalTest extends \PHPUnit\Framework\TestCase
         $expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         $actual = f\flatten($input);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testHead()
@@ -152,8 +152,8 @@ class FunctionalTest extends \PHPUnit\Framework\TestCase
         $expected = 1;
         $actual = f\head($input);
 
-        $this->assertEquals($expected, $actual);
-        $this->assertEquals([1, 2, 3, 4, 5], $input);
+        $this->assertSame($expected, $actual);
+        $this->assertSame([1, 2, 3, 4, 5], $input);
     }
 
     public function testLast()
@@ -162,8 +162,8 @@ class FunctionalTest extends \PHPUnit\Framework\TestCase
         $expected = 5;
         $actual = f\last($input);
 
-        $this->assertEquals($expected, $actual);
-        $this->assertEquals([1, 2, 3, 4, 5], $input);
+        $this->assertSame($expected, $actual);
+        $this->assertSame([1, 2, 3, 4, 5], $input);
     }
 
     public function testTail()
@@ -172,8 +172,8 @@ class FunctionalTest extends \PHPUnit\Framework\TestCase
         $expected = [2, 3, 4, 5];
         $actual = f\tail($input);
 
-        $this->assertEquals($expected, $actual);
-        $this->assertEquals([1, 2, 3, 4, 5], $input);
+        $this->assertSame($expected, $actual);
+        $this->assertSame([1, 2, 3, 4, 5], $input);
     }
 
     public function testInit()
@@ -182,8 +182,8 @@ class FunctionalTest extends \PHPUnit\Framework\TestCase
         $expected = [1, 2, 3, 4];
         $actual = f\init($input);
 
-        $this->assertEquals($expected, $actual);
-        $this->assertEquals([1, 2, 3, 4, 5], $input);
+        $this->assertSame($expected, $actual);
+        $this->assertSame([1, 2, 3, 4, 5], $input);
     }
 
     public function testUncons()
@@ -194,7 +194,7 @@ class FunctionalTest extends \PHPUnit\Framework\TestCase
         list($head, $tail) = f\uncons($input);
         $actual = [$head, $tail];
 
-        $this->assertEquals($expected, $actual);
-        $this->assertEquals([1, 2, 3, 4, 5], $input);
+        $this->assertSame($expected, $actual);
+        $this->assertSame([1, 2, 3, 4, 5], $input);
     }
 }

--- a/tests/Unit/Graphql/GraphqlResolverTest.php
+++ b/tests/Unit/Graphql/GraphqlResolverTest.php
@@ -30,7 +30,7 @@ class GraphqlResolverTest extends \PHPUnit\Framework\TestCase
         $schema = Graphql\schema($typeDefs, $resolvers);
         $actual = \GraphQL\GraphQL::execute($schema, $query);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testCallableResolver()
@@ -59,7 +59,7 @@ class GraphqlResolverTest extends \PHPUnit\Framework\TestCase
         $schema = Graphql\schema($typeDefs, $resolvers);
         $actual = \GraphQL\GraphQL::execute($schema, $query);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testMutation()
@@ -92,7 +92,7 @@ class GraphqlResolverTest extends \PHPUnit\Framework\TestCase
         $schema = Graphql\schema($typeDefs, $resolvers);
         $actual = \GraphQL\GraphQL::execute($schema, $query);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testObjectResolve()
@@ -120,6 +120,6 @@ class GraphqlResolverTest extends \PHPUnit\Framework\TestCase
         $schema = Graphql\schema($typeDefs, $resolvers);
         $actual = \GraphQL\GraphQL::execute($schema, $query);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/Unit/Graphql/SubscriptionManagerTest.php
+++ b/tests/Unit/Graphql/SubscriptionManagerTest.php
@@ -243,6 +243,6 @@ class SubscriptionManagerTest extends \PHPUnit\Framework\TestCase
 
         $manager = new SubscriptionManager($schema);
 
-        $this->assertEquals('test', $manager->getSubscriptionName($document));
+        $this->assertSame('test', $manager->getSubscriptionName($document));
     }
 }

--- a/tests/Unit/Http/HttpTest.php
+++ b/tests/Unit/Http/HttpTest.php
@@ -18,17 +18,17 @@ class HttpTest extends TestCase
 
     public function testCookie()
     {
-        $this->assertEquals($_COOKIE, Http\cookie());
-        $this->assertEquals('bar', Http\cookie('foo'));
-        $this->assertEquals('qux', Http\cookie('baz', 'qux'));
+        $this->assertSame($_COOKIE, Http\cookie());
+        $this->assertSame('bar', Http\cookie('foo'));
+        $this->assertSame('qux', Http\cookie('baz', 'qux'));
         $this->assertNull(Http\cookie('baz'));
     }
 
     public function testSession()
     {
-        $this->assertEquals($_SESSION, Http\session());
-        $this->assertEquals('bar', Http\session('foo'));
-        $this->assertEquals('qux', Http\session('baz', 'qux'));
+        $this->assertSame($_SESSION, Http\session());
+        $this->assertSame('bar', Http\session('foo'));
+        $this->assertSame('qux', Http\session('baz', 'qux'));
         $this->assertNull(Http\session('baz'));
     }
 
@@ -44,19 +44,19 @@ class HttpTest extends TestCase
     {
         $actual = Http\flash('foo');
 
-        $this->assertEquals('bar', $actual);
+        $this->assertSame('bar', $actual);
         $this->assertNull(Http\session('foo'));
     }
 
     public function testUrl()
     {
-        $this->assertEquals('/foo/qux', Http\url('/qux'));
-        $this->assertEquals('/foo/', Http\url());
+        $this->assertSame('/foo/qux', Http\url('/qux'));
+        $this->assertSame('/foo/', Http\url());
     }
 
     public function testPath()
     {
-        $this->assertEquals('/bar/baz', Http\path());
+        $this->assertSame('/bar/baz', Http\path());
     }
 
     /**
@@ -67,12 +67,12 @@ class HttpTest extends TestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $_SERVER['REQUEST_URI'] = '/foo/bar';
 
-        $this->assertEquals('/foo/bar', Http\path());
+        $this->assertSame('/foo/bar', Http\path());
     }
 
     public function testUri()
     {
-        $this->assertEquals('http://test:8000/bar/baz', Http\uri());
+        $this->assertSame('http://test:8000/bar/baz', Http\uri());
     }
 
     /**

--- a/tests/Unit/Http/RequestTest.php
+++ b/tests/Unit/Http/RequestTest.php
@@ -21,7 +21,7 @@ class RequestTest extends TestCase
     public function testRaw()
     {
         $rawContent = Request\raw(__DIR__.'/../../fixtures/php_input.txt');
-        $this->assertEquals('foo=bar', $rawContent);
+        $this->assertSame('foo=bar', $rawContent);
     }
 
     public function testParams()
@@ -62,52 +62,52 @@ class RequestTest extends TestCase
     public function testHeader()
     {
         $contentType = Request\header('Content-Type');
-        $this->assertEquals('phpunit/test', $contentType);
+        $this->assertSame('phpunit/test', $contentType);
     }
 
     public function testGet()
     {
-        $this->assertEquals($_GET, Request\get());
-        $this->assertEquals('bar', Request\get('foo'));
-        $this->assertEquals('qux', Request\get('baz', 'qux'));
+        $this->assertSame($_GET, Request\get());
+        $this->assertSame('bar', Request\get('foo'));
+        $this->assertSame('qux', Request\get('baz', 'qux'));
         $this->assertNull(Request\get('baz'));
     }
 
     public function testPost()
     {
-        $this->assertEquals($_POST, Request\post());
-        $this->assertEquals('bar', Request\post('foo'));
-        $this->assertEquals('qux', Request\post('baz', 'qux'));
+        $this->assertSame($_POST, Request\post());
+        $this->assertSame('bar', Request\post('foo'));
+        $this->assertSame('qux', Request\post('baz', 'qux'));
         $this->assertNull(Request\post('baz'));
     }
 
     public function testInput()
     {
-        $this->assertEquals($_REQUEST, Request\input());
-        $this->assertEquals('bar', Request\input('foo'));
-        $this->assertEquals('qux', Request\input('baz', 'qux'));
+        $this->assertSame($_REQUEST, Request\input());
+        $this->assertSame('bar', Request\input('foo'));
+        $this->assertSame('qux', Request\input('baz', 'qux'));
         $this->assertNull(Request\input('baz'));
     }
 
     public function testFile()
     {
-        $this->assertEquals($_FILES, Request\file());
-        $this->assertEquals('bar', Request\file('foo'));
-        $this->assertEquals('qux', Request\file('baz', 'qux'));
+        $this->assertSame($_FILES, Request\file());
+        $this->assertSame('bar', Request\file('foo'));
+        $this->assertSame('qux', Request\file('baz', 'qux'));
         $this->assertNull(Request\file('baz'));
     }
 
     public function testMethod()
     {
-        $this->assertEquals('GET', Request\method());
+        $this->assertSame('GET', Request\method());
 
         $_POST['_method'] = 'POST';
 
-        $this->assertEquals('POST', Request\method());
+        $this->assertSame('POST', Request\method());
 
         $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PUT';
 
-        $this->assertEquals('PUT', Request\method());
+        $this->assertSame('PUT', Request\method());
 
         unset($_POST['_method']);
         unset($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
@@ -146,40 +146,30 @@ class RequestTest extends TestCase
     public function testAcceptedLocales()
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.5';
-        $this->assertTrue(
-            array_keys(
-                Request\accepted_locales()
-            )[0] === 'en-US'
-        );
+        $this->assertSame('en-US', array_keys(Request\accepted_locales())[0]);
+
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = '';
-        $this->assertTrue(empty(Request\accepted_locales()));
+        $this->assertEmpty(Request\accepted_locales());
     }
 
     public function testRecommendedLocale()
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.5';
-        $this->assertTrue(
-            Request\recommended_locale() === 'en-US'
-        );
+        $this->assertSame('en-US', Request\recommended_locale());
+
         $_GET['lang'] = 'fr';
-        $this->assertTrue(
-            Request\recommended_locale() === 'fr'
-        );
+        $this->assertSame('fr', Request\recommended_locale());
+
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = '';
-        $this->assertTrue(
-            Request\recommended_locale() === 'fr'
-        );
+        $this->assertSame('fr', Request\recommended_locale());
+
         unset($_GET['lang']);
-        $this->assertTrue(
-            Request\recommended_locale('it') === 'it'
-        );
+        $this->assertSame('it', Request\recommended_locale('it'));
+
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.5';
-        $this->assertTrue(
-            Request\recommended_locale('it') === 'en-US'
-        );
+        $this->assertSame('en-US', Request\recommended_locale('it'));
+
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = '';
-        $this->assertTrue(
-            Request\recommended_locale() === \locale_get_default()
-        );
+        $this->assertSame(\locale_get_default(), Request\recommended_locale());
     }
 }

--- a/tests/Unit/Http/ResponseTest.php
+++ b/tests/Unit/Http/ResponseTest.php
@@ -16,7 +16,7 @@ class ResponseTest extends TestCase
 
         Response\output();
 
-        $this->assertEquals(204, http_response_code());
+        $this->assertSame(204, http_response_code());
         $this->assertContains('Content-Type: text/plain;charset=utf-8', xdebug_get_headers());
     }
 
@@ -26,7 +26,7 @@ class ResponseTest extends TestCase
 
         Response\text('foo');
 
-        $this->assertEquals(200, http_response_code());
+        $this->assertSame(200, http_response_code());
         $this->assertContains('Content-Type: text/plain;charset=utf-8', xdebug_get_headers());
     }
 
@@ -36,7 +36,7 @@ class ResponseTest extends TestCase
 
         Response\html('<a href="#"></a>');
 
-        $this->assertEquals(200, http_response_code());
+        $this->assertSame(200, http_response_code());
         $this->assertContains('Content-Type: text/html;charset=utf-8', xdebug_get_headers());
     }
 
@@ -46,7 +46,7 @@ class ResponseTest extends TestCase
 
         Response\json(['foo' => 'bar', 'baz' => true, 'qux' => 2]);
 
-        $this->assertEquals(200, http_response_code());
+        $this->assertSame(200, http_response_code());
         $this->assertContains('Content-Type: application/json;charset=utf-8', xdebug_get_headers());
     }
 
@@ -56,7 +56,7 @@ class ResponseTest extends TestCase
 
         Response\json(['error' => true, 'message' => 'test'], 400);
 
-        $this->assertEquals(400, http_response_code());
+        $this->assertSame(400, http_response_code());
     }
 
     public function testHeader()

--- a/tests/Unit/Jwt/JwtTest.php
+++ b/tests/Unit/Jwt/JwtTest.php
@@ -41,17 +41,17 @@ class JwtTest extends \PHPUnit\Framework\TestCase
     {
         $token = Jwt\builder($this->config)($this->data);
 
-        $this->assertEquals(self::JTI, $token->getHeader('jti'));
+        $this->assertSame(self::JTI, $token->getHeader('jti'));
 
-        $this->assertEquals(self::ISS, $token->getClaim('iss'));
-        $this->assertEquals(self::AUD, $token->getClaim('aud'));
+        $this->assertSame(self::ISS, $token->getClaim('iss'));
+        $this->assertSame(self::AUD, $token->getClaim('aud'));
         $this->assertEquals(self::IAT, $token->getClaim('iat'));
         $this->assertEquals(self::NBF, $token->getClaim('nbf'));
         $this->assertEquals(self::EXP, $token->getClaim('exp'));
 
-        $this->assertEquals(1, $token->getClaim('uid'));
+        $this->assertSame(1, $token->getClaim('uid'));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../../fixtures/jwt_unsigned.txt'), (string) $token);
+        $this->assertStringEqualsFile(__DIR__.'/../../fixtures/jwt_unsigned.txt', $token);
     }
 
     public function testValidate()
@@ -68,7 +68,7 @@ class JwtTest extends \PHPUnit\Framework\TestCase
     {
         $token = Jwt\builder($this->config, $this->signer, self::KEY)($this->data);
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../../fixtures/jwt_signed.txt'), (string) $token);
+        $this->assertStringEqualsFile(__DIR__.'/../../fixtures/jwt_signed.txt', $token);
 
         $this->assertTrue($token->verify($this->signer, self::KEY));
         $this->assertFalse($token->verify($this->signer, 'wrong key'));
@@ -78,15 +78,15 @@ class JwtTest extends \PHPUnit\Framework\TestCase
     {
         $token = Jwt\parse(file_get_contents(__DIR__.'/../../fixtures/jwt_signed.txt'));
 
-        $this->assertEquals(self::JTI, $token->getHeader('jti'));
+        $this->assertSame(self::JTI, $token->getHeader('jti'));
 
-        $this->assertEquals(self::ISS, $token->getClaim('iss'));
-        $this->assertEquals(self::AUD, $token->getClaim('aud'));
+        $this->assertSame(self::ISS, $token->getClaim('iss'));
+        $this->assertSame(self::AUD, $token->getClaim('aud'));
         $this->assertEquals(self::IAT, $token->getClaim('iat'));
         $this->assertEquals(self::NBF, $token->getClaim('nbf'));
         $this->assertEquals(self::EXP, $token->getClaim('exp'));
 
-        $this->assertEquals(1, $token->getClaim('uid'));
+        $this->assertSame(1, $token->getClaim('uid'));
 
         $this->assertTrue($token->verify($this->signer, self::KEY));
     }
@@ -94,6 +94,6 @@ class JwtTest extends \PHPUnit\Framework\TestCase
     public function testConf()
     {
         $config = Jwt\conf(self::ISS, self::AUD, self::JTI, self::IAT, self::NBF, self::EXP);
-        $this->assertEquals($this->config, $config);
+        $this->assertSame($this->config, $config);
     }
 }

--- a/tests/Unit/Ratchet/MessageComponentTest.php
+++ b/tests/Unit/Ratchet/MessageComponentTest.php
@@ -81,7 +81,7 @@ class MessageComponentTest extends \PHPUnit\Framework\TestCase
         $messageComponent->onMessage($this->conn, $message);
 
         $this->assertSame($this->conn, $onMessageFrom);
-        $this->assertEquals($message, $onMessageMessage);
+        $this->assertSame($message, $onMessageMessage);
     }
 
     public function testOnClose()

--- a/tests/Unit/Route/RoutePsr7Test.php
+++ b/tests/Unit/Route/RoutePsr7Test.php
@@ -32,7 +32,7 @@ class RoutePsr7Test extends \PHPUnit\Framework\TestCase
             return 'foo';
         });
 
-        $this->assertEquals('foo', $actual);
+        $this->assertSame('foo', $actual);
     }
 
     /**

--- a/tests/Unit/Route/RouteTest.php
+++ b/tests/Unit/Route/RouteTest.php
@@ -173,34 +173,34 @@ class RouteTest extends TestCase
             return 'foo';
         });
 
-        $this->assertEquals('foo', $actual);
+        $this->assertSame('foo', $actual);
     }
 
     public function testRegexify()
     {
-        $this->assertEquals('#^//?$#', Route\regexify('/'));
-        $this->assertEquals('#^/foo/?$#', Route\regexify('/foo'));
-        $this->assertEquals('#^/foo/bar/?$#', Route\regexify('/foo/bar'));
-        $this->assertEquals('#^/foo/(?<baz>[A-z0-9_-]+)/?$#', Route\regexify('/foo/{baz}'));
-        $this->assertEquals('#^/foo/(?<BaZ>[A-z0-9_-]+)/?$#', Route\regexify('/foo/{BaZ}'));
-        $this->assertEquals('#^/foo/(?<bar_baz>[A-z0-9_-]+)/?$#', Route\regexify('/foo/{bar_baz}'));
-        $this->assertEquals('#^/foo/(?<baz>[A-z0-9_-]+)/qux/?$#', Route\regexify('/foo/{baz}/qux'));
-        $this->assertEquals('#^/foo/(?<baz>[A-z0-9_-]+)?/?$#', Route\regexify('/foo/{baz}?'));
+        $this->assertSame('#^//?$#', Route\regexify('/'));
+        $this->assertSame('#^/foo/?$#', Route\regexify('/foo'));
+        $this->assertSame('#^/foo/bar/?$#', Route\regexify('/foo/bar'));
+        $this->assertSame('#^/foo/(?<baz>[A-z0-9_-]+)/?$#', Route\regexify('/foo/{baz}'));
+        $this->assertSame('#^/foo/(?<BaZ>[A-z0-9_-]+)/?$#', Route\regexify('/foo/{BaZ}'));
+        $this->assertSame('#^/foo/(?<bar_baz>[A-z0-9_-]+)/?$#', Route\regexify('/foo/{bar_baz}'));
+        $this->assertSame('#^/foo/(?<baz>[A-z0-9_-]+)/qux/?$#', Route\regexify('/foo/{baz}/qux'));
+        $this->assertSame('#^/foo/(?<baz>[A-z0-9_-]+)?/?$#', Route\regexify('/foo/{baz}?'));
     }
 
     public function testRoutify()
     {
-        $this->assertEquals(['get', '/'], Route\routify('\\index.get.php'));
-        $this->assertEquals(['get', '/'], Route\routify('index.get.php'));
-        $this->assertEquals(['get', '/'], Route\routify('/index.get.php'));
-        $this->assertEquals(['post', '/'], Route\routify('/index.post.php'));
-        $this->assertEquals(['get', '/foo'], Route\routify('/foo.get.php'));
-        $this->assertEquals(['get', '/foo'], Route\routify('/foo/index.get.php'));
-        $this->assertEquals(['get', '/foo/bar'], Route\routify('/foo.bar.get.php'));
-        $this->assertEquals(['get', '/foo/bar'], Route\routify('/foo/bar.get.php'));
-        $this->assertEquals(['get', '/foo/bar'], Route\routify('/foo/bar/index.get.php'));
-        $this->assertEquals(['get', '/foo/{id}'], Route\routify('/foo.{id}.get.php'));
-        $this->assertEquals(['get', '/foo/{id}'], Route\routify('/foo.$id.get.php'));
-        $this->assertEquals(['get', '/foo/?{id}?'], Route\routify('/foo.@id.get.php'));
+        $this->assertSame(['get', '/'], Route\routify('\\index.get.php'));
+        $this->assertSame(['get', '/'], Route\routify('index.get.php'));
+        $this->assertSame(['get', '/'], Route\routify('/index.get.php'));
+        $this->assertSame(['post', '/'], Route\routify('/index.post.php'));
+        $this->assertSame(['get', '/foo'], Route\routify('/foo.get.php'));
+        $this->assertSame(['get', '/foo'], Route\routify('/foo/index.get.php'));
+        $this->assertSame(['get', '/foo/bar'], Route\routify('/foo.bar.get.php'));
+        $this->assertSame(['get', '/foo/bar'], Route\routify('/foo/bar.get.php'));
+        $this->assertSame(['get', '/foo/bar'], Route\routify('/foo/bar/index.get.php'));
+        $this->assertSame(['get', '/foo/{id}'], Route\routify('/foo.{id}.get.php'));
+        $this->assertSame(['get', '/foo/{id}'], Route\routify('/foo.$id.get.php'));
+        $this->assertSame(['get', '/foo/?{id}?'], Route\routify('/foo.@id.get.php'));
     }
 }

--- a/tests/Unit/SilerTest.php
+++ b/tests/Unit/SilerTest.php
@@ -9,13 +9,13 @@ class SilerTest extends TestCase
     public function testArrayGet()
     {
         $fixture = ['foo' => 'bar'];
-        $this->assertEquals('bar', \Siler\array_get($fixture, 'foo'));
-        $this->assertEquals('qux', \Siler\array_get($fixture, 'baz', 'qux'));
+        $this->assertSame('bar', \Siler\array_get($fixture, 'foo'));
+        $this->assertSame('qux', \Siler\array_get($fixture, 'baz', 'qux'));
     }
 
     public function testRequireFn()
     {
         $cb = \Siler\require_fn(__DIR__.'/../fixtures/foo.php');
-        $this->assertEquals('baz', $cb(['bar' => 'baz']));
+        $this->assertSame('baz', $cb(['bar' => 'baz']));
     }
 }

--- a/tests/Unit/Twig/TwigTest.php
+++ b/tests/Unit/Twig/TwigTest.php
@@ -25,6 +25,6 @@ class TwigTest extends TestCase
     public function testRender()
     {
         Twig\init(__DIR__.'/../../fixtures');
-        $this->assertEquals('<p>bar</p>', Twig\render('template.twig', ['foo' => 'bar']));
+        $this->assertSame('<p>bar</p>', Twig\render('template.twig', ['foo' => 'bar']));
     }
 }


### PR DESCRIPTION
I made a little improvement to our tests, using:
- `assertSame` (`===`) instead of `assertEquals` (`==`), to find potential bugs;
- PHPUnit assertions instead of PHP method, to get better error messages in case of failure.