### PR TITLE
Fix bug on Route/files

### DIFF
--- a/src/Route/Route.php
+++ b/src/Route/Route.php
@@ -212,6 +212,15 @@ function files($basePath, $routePrefix = '', $request = null)
 
     foreach ($regex as $filename => $file) {
         list($method, $path) = routify(substr($filename, $cut));
-        route($method, $routePrefix.$path, $filename, $request);
+
+        if ('/' === $path) {
+            if ($routePrefix) {
+                $path = $routePrefix;
+            }
+        } else {
+            $path = $routePrefix . $path;
+        }
+
+        route($method, $path, $filename, $request);
     }
 }


### PR DESCRIPTION
Simple routePrefix concat with path leading bug when routePrefix supplied.
It should be fix the bug.
I found this bug when creating this [Siler-Crud-Example](https://github.com/eghojansu/siler-crud-sample).