### PR TITLE
fix deprecated warning since webonyx/graphql-php:0.12.0

### DIFF
--- a/src/Graphql/Graphql.php
+++ b/src/Graphql/Graphql.php
@@ -88,14 +88,14 @@ function execute(Schema $schema, array $input, $rootValue = null, $context = nul
     $operation = array_get($input, 'operation');
     $variables = array_get($input, 'variables');
 
-    return GraphQL::execute(
+    return GraphQL::executeQuery(
         $schema,
         $query,
         $rootValue,
         $context,
         $variables,
         $operation
-    );
+    )->toArray();
 }
 
 /**


### PR DESCRIPTION
Warning: Deprecated: GraphQL\GraphQL::execute is deprecated, use GraphQL::executeQuery()->toArray() as a quick replacement.

https://github.com/webonyx/graphql-php/commit/1b22f95a8655cd0ddd6143868ab00a99e81594f0

Closes #119 