### PR TITLE
fix operation name since webonyx/graphql-php:0.12.0

### DIFF
--- a/src/Graphql/Graphql.php
+++ b/src/Graphql/Graphql.php
@@ -85,7 +85,7 @@ function init(Schema $schema, $rootValue = null, $context = null, string $input 
 function execute(Schema $schema, array $input, $rootValue = null, $context = null)
 {
     $query = array_get($input, 'query');
-    $operation = array_get($input, 'operation');
+    $operation = array_get($input, 'operationName');
     $variables = array_get($input, 'variables');
 
     return GraphQL::execute(


### PR DESCRIPTION
Since [webonyx/graphql-php:0.12.0](https://github.com/webonyx/graphql-php/releases/tag/v0.12.0), server expect operationName (instead of operation) in input.
Current code expect 'operation' from input and get null value, hence the error:
'Must provide operation name if query contains multiple operations.'