### PR TITLE
(feature): add support for type config decorator

### DIFF
--- a/src/GraphQL/GraphQL.php
+++ b/src/GraphQL/GraphQL.php
@@ -140,17 +140,17 @@ function psr7(Schema $schema): Closure
  * Also sets a Siler's default field resolver based on $resolvers array.
  *
  * @param string $typeDefs
- * @param array $resolvers
+ * @param array  $resolvers
  *
  * @return Schema
  */
-function schema(string $typeDefs, array $resolvers = []): Schema
+function schema(string $typeDefs, array $resolvers = [], ?callable $typeConfigDecorator = null): Schema
 {
     if (!empty($resolvers)) {
         resolvers($resolvers);
     }
 
-    return BuildSchema::build($typeDefs);
+    return BuildSchema::build($typeDefs, $typeConfigDecorator);
 }
 
 /**


### PR DESCRIPTION
## Situation
This package wraps `webonyx/graphql-php`, but there is no fluent way to add `type config decorator` to the schema builder when using the `Type Query Language` to define Types.

## Proposal
The `Siler\GraphQL\schema()` should be adjusted to support `decorator` as an argument, so as to pass it onto `webonyx`'s `GraphQL\Utils\BuildSchema::build()`.

## Why is this needed?
[ See here to understand the context for usage](https://webonyx.github.io/graphql-php/type-system/type-language/#defining-resolvers)

It feels very natural to query against `Interface Types` and use `fragment` to select the `Sub-Types`.

In particular, the `$schema` could be passed to the `decorator` and used within the `$resolveTypes` declaration of an `Interface Type` to return an already existing `Object Type` from the schema - which would always throw an internal error if a new `Object Type` instance were supplied.

## Use Case
This is probably not the best use case implementation but, some code to give a general idea:

`schema.graphql`
```
interface Book  {
    id: ID!
    name: String!
}

type DefaultBook implements Book {
    id: ID!
    name: String!
}

type ChildrenBook implements Book {
    id: ID!
    name: String!
    child: Boolean!
}

type AdultBook implements Book {
    id: ID!
    name: String!
    adult: Boolean!
}

type Query {
    hello: String
    books (type: String): [Book!]
}
```
```
// Helper class to construct the schema 
class SilerInit
{
    /**
     * @var \GraphQL\Type\Schema
     */
    private $schema;

    public static function init() 
    {
        return new self();
    }

    public function schemaTypes(): string
    {
        return file_get_contents(__DIR__ . '/../schema.graphql');
    }

    public function resolvers(): array
    {
        $t = self::init();

        return [
            'Query' => [
                'hello' => "Hello Guys!",
                'books' => function ($root, $args) {
                    // base result to resemble interface
                    $base = [ "id" => rand(100, 200), "name" => "Peter Parker" ];
                    // just add the type supplied as a prop on the result 
                    $ext = isset($args['type']) && is_string($args['type']) ? [$args['type'] => true] : [];
                    // return an array of book object
                    return [ array_merge($base, $ext) ];
                },
            ]
        ];
    }

    public function decorator(): callable
    {
        return function($typeConfig, $typeDefinitionNode, $typeDefinitionNodeMap) {
            switch( $typeConfig["name"] ) {
                case "Book": // Interface Name
                    $typeConfig['resolveType'] = function ($value, $context, $resolverInfo) {
                        if(isset($value['child']))
                            return $this -> schema -> getType("ChildrenBook");
                        else if (isset($value['adult']))
                            return $this -> schema -> getType("AdultBook");
                        return $this -> schema -> getType("DefaultBook");
                    };
                    break;
            }
            return $typeConfig;
        };
    }

    public function setSchema($schema) 
    {
        $this -> schema = $schema;
    }
}
```
Let's use the class:

```
use \Siler\GraphQL;

class Init
{
    public static function silerGQL()
    {
        $siler = SilerInit::init();
        $schema = GraphQL\schema(
            $siler->schemaTypes(), $siler->resolvers(),  $siler->decorator()
        );
        $siler->setSchema($schema);
        GraphQL\init($schema);
    }
}

\Siler\Route\get('/api', Init::silerGQL());
```
Querying the server...
```
query Query{
  hello
  books(type: "child"){
    id
    name
    ... on AdultBook{
      adult
    }
    ... on ChildrenBook{
      child
    }
  }
}
```
## Note:
There are other scenarios where this also makes sense. For example, `Union Types` and may be more in the future.

**Disclaimer:** 
I am not aware of any other fluent way to do this, hence my reason for forking and submitting this PR. 