### PR TITLE
Add named regex param

### DIFF
--- a/src/Route/Route.php
+++ b/src/Route/Route.php
@@ -181,10 +181,13 @@ function method_path($request): array
  */
 function regexify(string $path): string
 {
-    $path = preg_replace('/\{([A-z-]+)\}/', '(?<$1>[A-z0-9_-]+)', $path);
-    $path = "#^{$path}/?$#";
+    $patterns = [
+        '/{([A-z-]+)}/' => '(?<$1>[A-z0-9_-]+)',
+        '/{([A-z-]+):(.*)}/' => '(?<$1>$2)',
+    ];
 
-    return $path;
+    $path = preg_replace(array_keys($patterns), array_values($patterns), $path);
+    return "#^{$path}/?$#";
 }
 
 /**

--- a/tests/Unit/Route/RouteTest.php
+++ b/tests/Unit/Route/RouteTest.php
@@ -199,6 +199,10 @@ class RouteTest extends TestCase
         $this->assertSame('#^/foo/(?<bar_baz>[A-z0-9_-]+)/?$#', Route\regexify('/foo/{bar_baz}'));
         $this->assertSame('#^/foo/(?<baz>[A-z0-9_-]+)/qux/?$#', Route\regexify('/foo/{baz}/qux'));
         $this->assertSame('#^/foo/(?<baz>[A-z0-9_-]+)?/?$#', Route\regexify('/foo/{baz}?'));
+
+        $this->assertSame('#^/foo/(?<baz>[0-9]+)/?$#', Route\regexify('/foo/{baz:[0-9]+}'));
+        $this->assertSame('#^/foo/(?<baz>[A-z]*)/?$#', Route\regexify('/foo/{baz:[A-z]*}'));
+        $this->assertSame('#^/foo/(?<baz>foo|bar|baz)/?$#', Route\regexify('/foo/{baz:foo|bar|baz}'));
     }
 
     public function testRoutify()


### PR DESCRIPTION
Closes #190 

```php
use function Siler\Route\{did_match, get};
use function Siler\Http\Response\json;

get('/{foo:[0-9]+}', function (array $params) {
    json($params['foo']);
});

if (!did_match()) {
    json('not found', 404);
}
```
```http
GET /123
"123"
```
```http
GET /foo
"not found"
```