### PR TITLE
Add Route/cancel()

### DIFF
--- a/src/Route/Route.php
+++ b/src/Route/Route.php
@@ -28,6 +28,7 @@ use const Siler\Swoole\SWOOLE_HTTP_REQUEST;
 
 const DID_MATCH = 'route_did_match';
 const STOP_PROPAGATION = 'route_stop_propagation';
+const CANCEL = 'route_cancel';
 
 /**
  * Define a new route using the GET HTTP method.
@@ -125,6 +126,10 @@ function any(string $path, $callback, $request = null)
  */
 function route($method, string $path, $callback, $request = null)
 {
+    if (canceled()) {
+        return null;
+    }
+
     if (did_match() && Container\get(STOP_PROPAGATION, true)) {
         return null;
     }
@@ -396,11 +401,30 @@ function stop_propagation()
 }
 
 /**
+ * Avoids routes to be called even on a match.
+ */
+function cancel()
+{
+    Container\set(CANCEL, true);
+}
+
+/**
+ * Returns true if routing is canceled.
+ *
+ * @return bool
+ */
+function canceled(): bool
+{
+    return Container\get(CANCEL, false);
+}
+
+/**
  * Resets default routing behaviour.
  */
 function resume()
 {
     Container\set(STOP_PROPAGATION, false);
+    Container\set(CANCEL, false);
 }
 
 /**

--- a/tests/Unit/Route/RouteTest.php
+++ b/tests/Unit/Route/RouteTest.php
@@ -10,6 +10,9 @@ use Siler\Route;
 use Siler\Test\Unit\Route\SwooleHttpRequestMock;
 use Zend\Diactoros\ServerRequest;
 
+use function Siler\Functional\always;
+use function Siler\Functional\Monad\identity;
+
 use const Siler\Swoole\SWOOLE_HTTP_REQUEST;
 
 class RouteTest extends TestCase
@@ -250,6 +253,23 @@ class RouteTest extends TestCase
         Container\set(SWOOLE_HTTP_REQUEST, new SwooleHttpRequestMock('DELETE', '/qux'));
         $methodPath = Route\method_path(null);
         $this->assertSame(['DELETE', '/qux'], $methodPath);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCancel()
+    {
+        $result = Route\get('/bar/baz', always('foo'));
+        $this->assertFalse(Route\canceled());
+        $this->assertSame('foo', $result);
+
+        Route\resume();
+        Route\cancel();
+
+        $result = Route\get('/bar/baz', always('foo'));
+        $this->assertTrue(Route\canceled());
+        $this->assertNull($result);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Adding `Route\cancel()` as a way to prevent route matches outside de Route flow (`Route\stop_propagation()`).
Closes #212 