### PR TITLE
Add pipe and conduit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Support middleware-like pipelines in Swoole with `Swoole\middleware`
 - Add `Swoole\redirect()` sugar
 - New `Siler\Env` API
-- Add `map` and `lmap` functions
+- Add `map`, `lmap`, `pipe`, `conduit` and `lconcat` functions
 
 # 1.7.1
 - Fix string callable on route

--- a/src/facades.php
+++ b/src/facades.php
@@ -83,6 +83,9 @@ const lazy = '\Siler\Functional\lazy';
 const call = '\Siler\Functional\call';
 const map = '\Siler\Functional\map';
 const lmap = '\Siler\Functional\lmap';
+const pipe = '\Siler\Functional\pipe';
+const conduit = '\Siler\Functional\conduit';
+const lconcat = '\Siler\Functional\lconcat';
 
 
 namespace Siler\Functional\Monad;

--- a/tests/Unit/Functional/FunctionalTest.php
+++ b/tests/Unit/Functional/FunctionalTest.php
@@ -296,4 +296,27 @@ class FunctionalTest extends TestCase
 
         $this->assertSame([2, 4, 6], $double([1, 2, 3]));
     }
+
+    public function testPipe()
+    {
+        $pipe = f\pipe([
+            f\add(1),
+            f\add(1),
+            f\add(1),
+        ]);
+
+        $this->assertSame(3, $pipe(0));
+    }
+
+    public function testConduit()
+    {
+        $this->assertSame('foo', f\conduit([f\always(null)])('foo'));
+
+        $this->assertSame(
+            'foobar',
+            f\conduit([
+                f\lconcat()('bar')
+            ])('foo')
+        );
+    }
 }


### PR DESCRIPTION
`compose` API preserved.
Added `pipe` and `conduit` that behaves similar do `pipe` but short-circuits on `null` returning the last non-null value.
Extra: `lconcat`, lazy version of `concat`.
Closes #244 