### PR TITLE
Allow nullable fields with GraphQL annotations

### DIFF
--- a/src/GraphQL/Annotation/Field.php
+++ b/src/GraphQL/Annotation/Field.php
@@ -31,4 +31,9 @@ final class Field
      * @psalm-var string|null
      */
     public $listOf;
+    /**
+     * @var boolean
+     * @psalm-var boolean
+     */
+    public $nullable = false;
 }

--- a/src/GraphQL/Deannotator.php
+++ b/src/GraphQL/Deannotator.php
@@ -233,7 +233,7 @@ final class Deannotator
 
         $type = $this->typeFromString($type);
 
-        if ($type instanceof Definition\NullableType) {
+        if (!$annotation->nullable && $type instanceof Definition\NullableType) {
             $type = Definition\Type::nonNull($type);
         }
 


### PR DESCRIPTION
Simple changes that make nullable fields possible with GraphQL annotations approach.

Example code:
```php
/**
 * @ObjectType
 */
class Query
{
    /**
     * @Field(type="String", nullable=true)
     */
    public static function nullableField()
    {
        return null;
    }
}
```
Resulting SDL:
```graphql
type Query {
  nullableField: String
  #Note that there's no exclamation sign
}
```