### PR TITLE
Added lazy injection feature to Container module

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -12,12 +12,12 @@ use function Siler\array_get;
  *
  * @param string $key The key to be searched on the container
  * @param mixed $default Default value when the key does not exists on the container
- * @var mixed $value
  * @return mixed|null
  */
 function get(string $key, $default = null)
 {
     $container = Container::getInstance();
+    /** @var mixed $value */
     $value = array_get($container->values, $key, $default);
 
     if (is_callable($value)) {
@@ -86,7 +86,6 @@ function inject(string $serviceName, $service): void
  * Useful for dependency injection/IoC.
  *
  * @param string $serviceName
- * @var mixed $service
  * @return mixed
  */
 function retrieve(string $serviceName)
@@ -97,6 +96,7 @@ function retrieve(string $serviceName)
         throw new UnderflowException("$serviceName not initialized");
     }
 
+    /** @var mixed $service */
     $service = $container->values[$serviceName];
 
     if (is_callable($service)) {

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -4,6 +4,7 @@ namespace Siler\Container;
 
 use OverflowException;
 use UnderflowException;
+use function Siler\Functional\call;
 use function Siler\array_get;
 
 /**
@@ -16,7 +17,13 @@ use function Siler\array_get;
 function get(string $key, $default = null)
 {
     $container = Container::getInstance();
-    return array_get($container->values, $key, $default);
+    $value = array_get($container->values, $key, $default);
+
+    if (is_callable($value)) {
+        return call($value);
+    }
+
+    return $value;
 }
 
 /**
@@ -88,7 +95,13 @@ function retrieve(string $serviceName)
         throw new UnderflowException("$serviceName not initialized");
     }
 
-    return $container->values[$serviceName];
+    $service = $container->values[$serviceName];
+
+    if (is_callable($service)) {
+        return call($service);
+    }
+
+    return $service;
 }
 
 /**

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -12,6 +12,7 @@ use function Siler\array_get;
  *
  * @param string $key The key to be searched on the container
  * @param mixed $default Default value when the key does not exists on the container
+ * @var mixed $value
  * @return mixed|null
  */
 function get(string $key, $default = null)
@@ -85,6 +86,7 @@ function inject(string $serviceName, $service): void
  * Useful for dependency injection/IoC.
  *
  * @param string $serviceName
+ * @var mixed $service
  * @return mixed
  */
 function retrieve(string $serviceName)

--- a/tests/Unit/Container/ContainerTest.php
+++ b/tests/Unit/Container/ContainerTest.php
@@ -15,12 +15,17 @@ class ContainerTest extends TestCase
     public function testSet()
     {
         Container\set('test', 'test');
+        Container\set('lazy', static function () {
+            return 'lazy';
+        });
         $this->assertContains('test', Container\Container::getInstance()->values);
+        $this->assertContains('lazy', Container\Container::getInstance()->values);
     }
 
     public function testGet()
     {
         $this->assertSame('test', Container\get('test'));
+        $this->assertSame('lazy', Container\get('lazy'));
     }
 
     public function testHas()
@@ -63,5 +68,6 @@ class ContainerTest extends TestCase
         $service = new stdClass();
         Container\Container::getInstance()->values['test_retrieve'] = $service;
         $this->assertSame($service, Container\retrieve('test_retrieve'));
+        $this->assertSame('lazy', Container\retrieve('lazy'));
     }
 }


### PR DESCRIPTION
This PR introduces lazy injection to Container module.

```php
Container\set(
    'lazyServiceName',
    function() {
        return 'lazyService';
    }
);
```
```php
Container\get('lazyServiceName'); // it returns 'lazyService'!
```