### PR TITLE
sugar for GraphQL validation rules

### DIFF
--- a/src/GraphQL/GraphQL.php
+++ b/src/GraphQL/GraphQL.php
@@ -487,11 +487,11 @@ function annotated(array $class_names, array $with_types = [], array $with_direc
 /**
  * Adds rule to list of global validation rules
  *
- * @param array<ValidationRule> $validationRules
+ * @param array<ValidationRule> $rules
  */
-function addValidationRules(array $validationRules): void
+function validation_rules(array $rules): void
 {
-    foreach ($validationRules as $validationRule) {
-        DocumentValidator::addRule($validationRule);
+    foreach ($rules as $rule) {
+        DocumentValidator::addRule($rule);
     }
 }

--- a/src/GraphQL/GraphQL.php
+++ b/src/GraphQL/GraphQL.php
@@ -19,6 +19,8 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
+use GraphQL\Validator\DocumentValidator;
+use GraphQL\Validator\Rules\ValidationRule;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ServerRequestInterface;
 use Ratchet\Server\IoServer;
@@ -480,4 +482,16 @@ function annotated(array $class_names, array $with_types = [], array $with_direc
 
     $deannotator = new Deannotator($with_types, $with_directives);
     return $deannotator->deannotate($class_names);
+}
+
+/**
+ * Adds rule to list of global validation rules
+ *
+ * @param array<ValidationRule> $validationRules
+ */
+function addValidationRules(array $validationRules): void
+{
+    foreach ($validationRules as $validationRule) {
+        DocumentValidator::addRule($validationRule);
+    }
 }

--- a/tests/Unit/GraphQL/GraphQLTest.php
+++ b/tests/Unit/GraphQL/GraphQLTest.php
@@ -108,9 +108,9 @@ class GraphQLTest extends TestCase
         $this->assertSame(0, GraphQL\debugging());
     }
 
-    public function testAddValidationRules()
+    public function testValidationRules()
     {
-        GraphQL\addValidationRules(
+        GraphQL\validation_rules(
             [
                 new QueryComplexity(10)
             ]

--- a/tests/Unit/GraphQL/GraphQLTest.php
+++ b/tests/Unit/GraphQL/GraphQLTest.php
@@ -6,6 +6,8 @@ use GraphQL\Error\DebugFlag;
 use GraphQL\Error\Error;
 use GraphQL\Executor\Promise\Adapter\SyncPromiseAdapter;
 use GraphQL\Type\Schema;
+use GraphQL\Validator\DocumentValidator;
+use GraphQL\Validator\Rules\QueryComplexity;
 use PHPUnit\Framework\TestCase;
 use Siler\Container;
 use Siler\GraphQL;
@@ -104,5 +106,16 @@ class GraphQLTest extends TestCase
         $this->assertSame(1, GraphQL\debugging());
         GraphQL\debug(0);
         $this->assertSame(0, GraphQL\debugging());
+    }
+
+    public function testAddValidationRules()
+    {
+        GraphQL\addValidationRules(
+            [
+                new QueryComplexity(10)
+            ]
+        );
+
+        $this->assertArrayHasKey(QueryComplexity::class, array_keys(DocumentValidator::allRules()));
     }
 }


### PR DESCRIPTION
This PR introduces namespaced function that adds custom validation rules to GraphQL executor.

Further reading:
- [Security - graphql-php](https://webonyx.github.io/graphql-php/security/)