### PR TITLE
Force default field resolver to look for public getter methods at first

### DIFF
--- a/src/GraphQL/GraphQL.php
+++ b/src/GraphQL/GraphQL.php
@@ -296,7 +296,14 @@ function resolvers(array $resolvers): void
                 }
 
                 if (is_object($resolver)) {
-                    if (isset($resolver->{$field_name})) {
+                    $getter = sprintf('get%s', ucwords($field_name));
+                    if (method_exists($resolver, $getter)) {
+                        $reflectionGetter = new \ReflectionMethod($resolver, $getter);
+                        if ($reflectionGetter->isPublic()) {
+                            $value = $resolver->{$getter}($source, $args, $context, $info);
+                        }
+                    }
+                    if ($value === null && isset($resolver->{$field_name})) {
                         /** @var callable|mixed $value */
                         $value = $resolver->{$field_name};
                     }

--- a/src/GraphQL/GraphQL.php
+++ b/src/GraphQL/GraphQL.php
@@ -300,6 +300,7 @@ function resolvers(array $resolvers): void
                     if (method_exists($resolver, $getter)) {
                         $reflectionGetter = new \ReflectionMethod($resolver, $getter);
                         if ($reflectionGetter->isPublic()) {
+                            /** @var mixed $value */
                             $value = $resolver->{$getter}($source, $args, $context, $info);
                         }
                     }


### PR DESCRIPTION
Field resolver looks for public getter method to resolve field. If such method doesn't exist or isn't public, then it continue resolving in standard way.

```php
// Doctrine's entity object
class User
{
  // We don't want to fetch all messages with Doctrine
  private Collection $messages;

  // we want to fetch only these messages that match our criteria
  public function getMessages($root, array $args, $context, ResolveInfo $resolveInfo): Collection
  {
    return $this->messages->matching(/* something */);
  }
}
```