### PR TITLE
feat(graphql): add GraphiQL Explorer

### DIFF
--- a/src/GraphQL/GraphiQL.php
+++ b/src/GraphQL/GraphiQL.php
@@ -11,59 +11,51 @@ namespace Siler\GraphQL;
 function graphiql(string $endpoint = 'http://localhost:8000/graphql'): string
 {
     return <<<HTML
-<!--
- *  Copyright (c) 2019 GraphQL Contributors
- *  All rights reserved.
- *
- *  This source code is licensed under the license found in the
- *  LICENSE file in the root directory of this source tree.
--->
 <!DOCTYPE html>
 <html>
   <head>
     <style>
+      html,
       body {
         height: 100%;
         margin: 0;
         width: 100%;
         overflow: hidden;
       }
-
       #graphiql {
         height: 100vh;
       }
     </style>
 
-    <!--
-      This GraphiQL example depends on Promise and fetch, which are available in
-      modern browsers, but can be "polyfilled" for older browsers.
-      GraphiQL itself depends on React DOM.
-      If you do not want to rely on a CDN, you can host these files locally or
-      include them directly in your favored resource bunder.
-    -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.css"
+      integrity="sha384-GBqwox+q8UtVEyBLBKloN5QDlBDsQnuoSUfMeJH1ZtDiCrrk103D7Bg/WjIvl4ya"
+      crossorigin="anonymous"
+    />
     <script
-      crossorigin
-      src="https://unpkg.com/react@16/umd/react.development.js"
+      src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.3/fetch.min.js"
+      integrity="sha384-dcF7KoWRaRpjcNbVPUFgatYgAijf8DqW6NWuqLdfB5Sb4Cdbb8iHX7bHsl9YhpKa"
+      crossorigin="anonymous"
     ></script>
     <script
-      crossorigin
-      src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"
+      src="https://cdn.jsdelivr.net/npm/react@16.8.6/umd/react.production.min.js"
+      integrity="sha384-qn+ML/QkkJxqn4LLs1zjaKxlTg2Bl/6yU/xBTJAgxkmNGc6kMZyeskAG0a7eJBR1"
+      crossorigin="anonymous"
     ></script>
-
-    <!--
-      These two files can be found in the npm module, however you may wish to
-      copy them directly into your environment, or perhaps include them in your
-      favored resource bundler.
-     -->
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+    <script
+      src="https://cdn.jsdelivr.net/npm/react-dom@16.8.6/umd/react-dom.production.min.js"
+      integrity="sha384-85IMG5rvmoDsmMeWK/qUU4kwnYXVpC+o9hoHMLi4bpNR+gMEiPLrvkZCgsr7WWgV"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
+      integrity="sha384-TqI6gT2PjmSrnEOTvGHLad1U4Vm5VoyzMmcKK0C/PLCWTnwPyXhCJY6NYhC/tp19"
+      crossorigin="anonymous"
+    ></script>
   </head>
-
   <body>
     <div id="graphiql">Loading...</div>
-    <script
-      src="https://unpkg.com/graphiql/graphiql.min.js"
-      type="application/javascript"
-    ></script>
     <script>
       function graphQLFetcher(graphQLParams) {
         return fetch(
@@ -83,9 +75,8 @@ function graphiql(string $endpoint = 'http://localhost:8000/graphql'): string
           });
         });
       }
-
       ReactDOM.render(
-        React.createElement(GraphiQL, {
+        React.createElement(GraphiQLWithExtensions.GraphiQLWithExtensions, {
           fetcher: graphQLFetcher,
           defaultVariableEditorOpen: true,
         }),


### PR DESCRIPTION
Parabéns pelo projeto, achei ele sensacional quando descobri !

Mas quando integrei o GraphiQL, vi que ele não vem com o Explorer, estou muito acostumado a usar ele e acho que ele deixa o schema muito mais visual, agradável de navegar e "descobrível".

Esse PR troca a integração atual do GraphiQL para o https://github.com/OneGraph/graphiql-with-extensions .

Eu usei [este arquivo](https://github.com/OneGraph/graphiql-with-extensions/blob/master/examples/static.html) como exemplo, por causa disso alguns comentários foram removidos.