### PR TITLE
New Feature: CORS Access-Control-Allow-Credentials

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -143,7 +143,7 @@ function no_content(): void
  *
  * @return void
  */
-function cors(string $origin = '*', string $headers = 'Content-Type', string $methods = 'GET, POST, PUT, DELETE'): void
+function cors(string $origin = '*', string $headers = 'Content-Type', string $methods = 'GET, POST, PUT, DELETE', string $credentials = 'true'): void
 {
     if (Container\has(SWOOLE_HTTP_REQUEST)) {
         \Siler\Swoole\cors();
@@ -153,6 +153,7 @@ function cors(string $origin = '*', string $headers = 'Content-Type', string $me
     header('Access-Control-Allow-Origin', $origin);
     header('Access-Control-Allow-Headers', $headers);
     header('Access-Control-Allow-Methods', $methods);
+    header('Access-Control-Allow-Credentials', $credentials);
 
     if (Request\method_is('options')) {
         no_content();

--- a/src/Swoole/Swoole.php
+++ b/src/Swoole/Swoole.php
@@ -284,7 +284,7 @@ function broadcast(string $message): void
  *
  * @return void
  */
-function cors(string $origin = '*', string $headers = 'Content-Type, Authorization', string $methods = 'GET, POST, PUT, DELETE'): void
+function cors(string $origin = '*', string $headers = 'Content-Type, Authorization', string $methods = 'GET, POST, PUT, DELETE', string $credentials = 'true'): void
 {
     /** @var Response $response */
     $response = Container\get(SWOOLE_HTTP_RESPONSE);
@@ -292,6 +292,7 @@ function cors(string $origin = '*', string $headers = 'Content-Type, Authorizati
     $response->header('Access-Control-Allow-Origin', $origin);
     $response->header('Access-Control-Allow-Headers', $headers);
     $response->header('Access-Control-Allow-Methods', $methods);
+    $response->header('Access-Control-Allow-Credentials', $credentials);
 
     /** @var Request $request */
     $request = Container\get(SWOOLE_HTTP_REQUEST);

--- a/tests/Unit/Http/ResponseTest.php
+++ b/tests/Unit/Http/ResponseTest.php
@@ -129,7 +129,7 @@ class ResponseTest extends TestCase
             $this->assertContains('Access-Control-Allow-Origin: *', $headers);
             $this->assertContains('Access-Control-Allow-Headers: Content-Type', $headers);
             $this->assertContains('Access-Control-Allow-Methods: GET, POST, PUT, DELETE', $headers);
-            $this->assertContains('Access-Control-Allow-Credentials', $headers);
+            $this->assertContains('Access-Control-Allow-Credentials: true', $headers);
         } else {
             $this->assertTrue(true);
         }

--- a/tests/Unit/Http/ResponseTest.php
+++ b/tests/Unit/Http/ResponseTest.php
@@ -125,12 +125,11 @@ class ResponseTest extends TestCase
 
         if (function_exists('xdebug_get_headers')) {
             $headers = xdebug_get_headers();
-            $credentials = 'true';
 
             $this->assertContains('Access-Control-Allow-Origin: *', $headers);
             $this->assertContains('Access-Control-Allow-Headers: Content-Type', $headers);
             $this->assertContains('Access-Control-Allow-Methods: GET, POST, PUT, DELETE', $headers);
-            $this->assertContains('Access-Control-Allow-Credentials', $credentials);
+            $this->assertContains('Access-Control-Allow-Credentials', $headers);
         } else {
             $this->assertTrue(true);
         }

--- a/tests/Unit/Http/ResponseTest.php
+++ b/tests/Unit/Http/ResponseTest.php
@@ -129,6 +129,7 @@ class ResponseTest extends TestCase
             $this->assertContains('Access-Control-Allow-Origin: *', $headers);
             $this->assertContains('Access-Control-Allow-Headers: Content-Type', $headers);
             $this->assertContains('Access-Control-Allow-Methods: GET, POST, PUT, DELETE', $headers);
+            $this->assertContains('Access-Control-Allow-Credentials', $credentials);
         } else {
             $this->assertTrue(true);
         }

--- a/tests/Unit/Http/ResponseTest.php
+++ b/tests/Unit/Http/ResponseTest.php
@@ -125,6 +125,7 @@ class ResponseTest extends TestCase
 
         if (function_exists('xdebug_get_headers')) {
             $headers = xdebug_get_headers();
+            $credentials = 'true';
 
             $this->assertContains('Access-Control-Allow-Origin: *', $headers);
             $this->assertContains('Access-Control-Allow-Headers: Content-Type', $headers);


### PR DESCRIPTION
I'm new to contributing so please be gentle if I'm doing it wrong!

I've updated CORS to include an Access-Control-Allow-Credentials header.  
This makes it possible to pass authentication information such as cookies, or in my case use an SSL Client Certificate in order to protect my API.

