### PR TITLE
README: make install command copy-pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Flat files and plain-old PHP functions rocking on a production-grade, high-perfo
 ### Installation
 
 ```bash
-$ composer require leocavalcante/siler
+composer require leocavalcante/siler
 ```
 
 That is it. Actually, Siler is a library, not a framework (maybe a micro-framework), the overall program flow of control is dictated by you. So, no hidden configs or predefined directory structures.


### PR DESCRIPTION
This makes click and paste possible from GitHub, besides the other install commands are without shell prompt.